### PR TITLE
fix: disable power button during programming mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-##
+## 0.7.0
 - Power- and dark mode button indicate current status ([#127](https://github.com/OpenRemise/Frontend/issues/127))
 - Bugfix various bugs
   - `connectionStatusProvider` burns CPU on disconnect ([#123](https://github.com/OpenRemise/Frontend/issues/123))

--- a/lib/screen/program.dart
+++ b/lib/screen/program.dart
@@ -59,7 +59,7 @@ class _ProgramScreenState extends ConsumerState<ProgramScreen> {
     final type = _selected.elementAtOrNull(0) == 0 ? Loco : Turnout;
     final serviceMode = _selected.elementAtOrNull(1) == 1;
     final address = int.tryParse(_formKey.currentState?.value['address'] ?? '');
-    final decoder = Decoder(type: type, address: address);
+    final decoder = Decoder(type: type, address: serviceMode ? null : address);
     final smallWidth = MediaQuery.of(context).size.width < smallScreenWidth;
 
     return Padding(

--- a/lib/widget/power_icon_button.dart
+++ b/lib/widget/power_icon_button.dart
@@ -36,13 +36,15 @@ class PowerIconButton extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     return ref.watch(z21StatusProvider).when(
           data: (status) {
-            final z21 = ref.watch(z21ServiceProvider);
             final off = status.trackVoltageOff();
             final prog = status.programmingMode();
             return IconButton(
-              onPressed: () =>
-                  z21(off ? LanXSetTrackPowerOn() : LanXSetTrackPowerOff()),
-              tooltip: off ? 'Power on' : 'Power off',
+              onPressed: prog
+                  ? null
+                  : () => ref.read(z21ServiceProvider)(
+                        off ? LanXSetTrackPowerOn() : LanXSetTrackPowerOff(),
+                      ),
+              tooltip: prog ? null : (off ? 'Power on' : 'Power off'),
               isSelected: !off || prog,
               selectedIcon:
                   Icon(Icons.power, color: prog ? Colors.blue : Colors.green),


### PR DESCRIPTION
Users can now no longer accidentally clicking the power button while programming mode is active.