### PR TITLE
fix: higher functions F31-F13 from `LAN_X_LOCO_INFO` incorrectly shif…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Add VCC voltage and hardware revision to info screen ([#143](https://github.com/OpenRemise/Frontend/pull/143))
 - Blue power off icon indicates short circuit ([#143](https://github.com/OpenRemise/Frontend/pull/143))
 - Allow smaller text scaling (0.8) ([#158](https://github.com/OpenRemise/Frontend/issues/158))
+- Bugfix higher functions F31-F13 from `LAN_X_LOCO_INFO` incorrectly shifted ([#162](https://github.com/OpenRemise/Frontend/issues/162))
 
 ## 0.7.1
 - Bugfix empty SSID is valid ([#133](https://github.com/OpenRemise/Frontend/issues/133))

--- a/lib/data/services/roco/z21.dart
+++ b/lib/data/services/roco/z21.dart
@@ -1285,12 +1285,13 @@ class LanXLocoInfo extends Z21Command {
         rvvvvvvv = dataset[8],
         doubleTraction = dataset[9] & (1 << 6) == (1 << 6),
         smartSearch = dataset[9] & (1 << 5) == (1 << 5),
-        f31_0 = dataset.sublist(11, dataset.length - 1).fold(
-                  dataset[10] << 5,
-                  (previousValue, element) => element << 8 | previousValue,
-                ) | // F31-F5
-            ((dataset[9] & 0x0F) << 1) | // F4-F1
-            ((dataset[9] & (1 << 4)) >> 4) // F0
+        f31_0 =
+            dataset.sublist(10, dataset.length - 1).asMap().entries.fold<int>(
+                      0,
+                      (v, e) => v | (e.value << (5 + e.key * 8)),
+                    ) | // F31-F5
+                ((dataset[9] & 0x0F) << 1) | // F4-F1
+                ((dataset[9] & (1 << 4)) >> 4) // F0
   {
     assert(dataset.length >= 0x0F);
   }


### PR DESCRIPTION
Functions from `LAN_X_LOCO_INFO` were not shifted in correctly.

<img width="794" height="1069" alt="image" src="https://github.com/user-attachments/assets/2d969132-b2f9-4bf9-b4c2-c98ed6e555f2" />


Closes #162