### PR TITLE
chore: add git identifier to artifacts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,16 +101,18 @@ endif()
 # Build web
 add_custom_target(Frontend ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/web)
 
-# Create Frontend-${PROJECT_VERSION}.zip
+# Create Frontend-${PROJECT_VERSION}${IDENTIFIERS_FROM_GIT}.zip
 if(CMAKE_BUILD_TYPE STREQUAL Release)
   add_custom_target(
     FrontendRelease
-    COMMAND ${CMAKE_COMMAND} -E tar "cf" ${PROJECT_NAME}-${PROJECT_VERSION}.zip
-            --format=zip *
+    COMMAND
+      ${CMAKE_COMMAND} -E tar "cf"
+      ${PROJECT_NAME}-${PROJECT_VERSION}${IDENTIFIERS_FROM_GIT}.zip --format=zip
+      *
     COMMAND
       ${CMAKE_COMMAND} -E rename
-      ${CMAKE_CURRENT_BINARY_DIR}/web/${PROJECT_NAME}-${PROJECT_VERSION}.zip
-      ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-${PROJECT_VERSION}.zip
+      ${CMAKE_CURRENT_BINARY_DIR}/web/${PROJECT_NAME}-${PROJECT_VERSION}${IDENTIFIERS_FROM_GIT}.zip
+      ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-${PROJECT_VERSION}${IDENTIFIERS_FROM_GIT}.zip
     DEPENDS Frontend
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/web)
 endif()


### PR DESCRIPTION
Append git identifiers to the generated artifacts to make it easier to distinguish between builds in the future.